### PR TITLE
User account changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apk add --update build-base curl bash && \
     apk del build-base curl emacs ocaml && \
     # Remove tmp files and caches
     rm -rf /var/cache/apk/* && \
-    rm -rf /tmp/unison-${UNISON_VERSION}
+    rm -rf /tmp/unison-${UNISON_VERSION} && \
+    deluser xfs
 
 # These can be overridden later
 ENV TZ="Europe/Helsinki" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# Create user and group for wordpress
+# Create unison user and group
 addgroup -g $UNISON_GID $UNISON_GROUP
-adduser -u $UNISON_UID -g $UNISON_GID $UNISON_USER
+adduser -u $UNISON_UID -G $UNISON_GROUP -s /bin/bash $UNISON_USER
 
 # Create directory for filesync
 if [ ! -d "$UNISON_DIR" ]; then


### PR DESCRIPTION
Not sure if all of these changes fall within the scope of this project, but here goes.

## Removed: `xfs` user

The default `X Font Server` user occupies uid and gid `33`. Other distributions (and therefore other container images) have user accounts for `www-data` or `http` in this spot, which makes these ids very desirable for permissions reasons. I believe it is unlikely that anyone will miss the `xfs` user when it is gone. With this change, I can set the following environment variables:

```
UNISON_UID=33
UNISON_GID=33
```

...and now I don't have to `chown` all my files all the time!

## Fixed: Unison user GID

The `-g` flag for the `adduser` command adds data to the GECOS field, and does not affect the user's group id. This has been changed to `-G` to set the group of the user instead of their GECOS data.