### PR TITLE
Docker complained about this line when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ENV TZ="Europe/Helsinki" \
     LANG="C.UTF-8" \
     UNISON_DIR="/data" \
     HOME="/tmp" \
-
     ##
     # Use 1000:1001 as default user
     ##


### PR DESCRIPTION
The message from Docker was:
[WARNING]: Empty continuation line found in:
    ENV TZ="Europe/Helsinki"     LANG="C.UTF-8"....
[WARNING]: Empty continuation lines will become errors in a future release.