### PR TITLE
add /data volume in the example, use actual path in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The docker image is available on Docker Hub:
 First, you can launch a volume container exposing a volume with Unison.
 
 ```bash
-$ CID=$(docker run -d -p 5000:5000 -e UNISON_DIR=/data onnimonni/unison)
+$ CID=$(docker run -d -p 5000:5000 -e UNISON_DIR=/data -v /data onnimonni/unison)
 ```
 
 You can then sync a local folder to `$UNISON_DIR` (default value: `/data`) in the container with:
@@ -65,7 +65,7 @@ unison:
     - /var/www/project
 ```
 
-You can then sync a local folder, using the unison client, to `/unison` in the container with:
+You can then sync a local folder, using the unison client, to `/var/www/project` in the container with:
 
 ```bash
 $ unison . socket://<docker>:5000/ -ignore 'Path .git' -auto -batch


### PR DESCRIPTION
If a user is just following these commands, the `-v /data` needs to be added so it works.
The /var/www/project is what is used in the docker compose snippet, so it seems the text should refer to that. 

One thing to note which is that with these examples the `/unison` volume gets mounted along `$UNISON_DIR`.  This is because the Dockerfile creates this `/unison` volume and volumes-from mounts that volume along with the `/data` or `/var/www/project` volume. 