### PR TITLE
use tini and su-exec to pass signals and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG UNISON_VERSION=2.51.2
 
 # Install in one run so that build tools won't remain in any docker layers
 # Install build tools
-RUN apk add --update build-base curl bash && \
+RUN apk add --update build-base curl bash su-exec tini && \
     # Install ocaml & emacs from testing repositories
     apk add --update-cache --repository http://dl-4.alpinelinux.org/alpine/edge/testing/ ocaml emacs && \
     # Download & Install Unison
@@ -42,4 +42,4 @@ COPY entrypoint.sh /entrypoint.sh
 VOLUME /unison
 
 EXPOSE 5000
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,15 +27,5 @@ chown -R $UNISON_USER:$UNISON_GROUP $UNISON_DIR
 # Start process on path which we want to sync
 cd $UNISON_DIR
 
-# Gracefully stop the process on 'docker stop'
-trap 'kill -TERM $PID' TERM INT
-
-# Run unison server as user wordpress
-su -c "unison -socket 5000 " $UNISON_USER &
-
-# Wait until the process is stopped
-PID=$!
-wait $PID
-trap - TERM INT
-wait $PID
-EXIT_STATUS=$?
+# Run unison server as UNISON_USER and pass signals through
+exec su-exec $UNISON_USER unison -socket 5000


### PR DESCRIPTION
tini is technically optional because you can pass the --init option to docker run
but asking people to do everytime they use this image seems annoying

without tini or --init the unison process runs as PID 1, and PID 1 does not have any default signal handlers.
So if the process does't install its own handlers the process won't be terminated.
It seems unison does not install these handlers.

The bash code with traps and waits does basically the same thing as tini.
tini should be a bit more robust than the previous bash code, but I don't have a specific test case
where tini is succeeds and the bash code fails.